### PR TITLE
Revert dependencias

### DIFF
--- a/labselector/package-lock.json
+++ b/labselector/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "labselector",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "labselector",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "axios": "^1.8.2",

--- a/labselector/package.json
+++ b/labselector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "labselector",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
This pull request includes minor version updates for the `labselector` package. The version has been incremented from `1.5.0` to `1.5.1` in both the `package.json` and `package-lock.json` files.

Version updates:

* [`labselector/package.json`](diffhunk://#diff-874485f1a7b9a83a4be48a846602245b54daca1c36455d7ce0e80828a6d5078bL3-R3): Updated the version from `1.5.0` to `1.5.1`.
* [`labselector/package-lock.json`](diffhunk://#diff-3b5b387f6f5055dc382a6a4cc0de8f6521cdb4ca7028bb7fb31d32f654d35976L3-R9): Updated the version from `1.5.0` to `1.5.1`.